### PR TITLE
Add modern JavaScript cheatsheet to references

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ This list is mainly about JavaScript – the language. Not about APIs, tooling, 
 - [MDN](https://developer.mozilla.org/docs/Web/JavaScript/Reference) - Simply the best language reference.
 - [DevDocs](http://devdocs.io/javascript) - Search MDN comfortably. Even offline.
 - [Simplified JavaScript Jargon](http://jargon.js.org) – Glossary which explains all the buzzwords from the JavaScript eco system.
+- [Modern JavaScript Cheatsheet](https://github.com/mbeaudru/modern-js-cheatsheet) – Helps developers with basic knowledge to get familiar with modern codebases.
 - [ECMAScript® Language Specification](http://ecma-international.org/publications/standards/Ecma-262.htm) - The standard JavaScript is based on. Only for very advanced learners.
 
 ## Tutorials


### PR DESCRIPTION
That’s it :octocat: 
