### PR TITLE
Add Cross-platform Node.js guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ Thin books which you can get through in a few days.
 - [NodeSchool](https://nodeschool.io) - Interactive self guided workshops you can also do on your own.
 - [Node Patterns](http://nodepatternsbooks.com) - Short books about code and networking patterns related to Node.js.
 - [Learn Node](https://learnnode.com) - A premium training course to learn to build apps with Node.js, Express, MongoDB.
+- [Cross-platform Node.js](https://github.com/ehmicky/cross-platform-node-guide) - How to write cross-platform Node.js code.
 
 ---
 


### PR DESCRIPTION
This adds [a guide](https://github.com/ehmicky/cross-platform-node-guide) to the Node.js section about writing cross-platform code. This is important since [Node.js users use different OSes](https://nodejs.org/en/user-survey-report/#Primary-OS-Distro). Also, non-cross-platform Node.js code is quite common in both production code and side projects.

[Additional similar resources](https://github.com/ehmicky/cross-platform-node-guide#see-also) are included in the guide.

---- 

By submitting this pull request, I promise that:

- [x] I have read the [contribution guidelines](https://github.com/micromata/awesome-javascript-learning/blob/master/.github/contributing.md) thoroughly.
- [x] I ensure my submission follows each and every point. 
