### PR TITLE
Added link of JavaScript Roadmap

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ This list is mainly about JavaScript - the language. Not about APIs, tooling, fr
 - [DOM related](#dom-related)
 - [Node.js](#nodejs)
 - [Related](#related)
+- [Roadmap](#roadmap)
 
 ---
 
@@ -127,3 +128,7 @@ Thin books which you can get through in a few days.
 ## Related
 
 [Awesome CSS Learning](https://github.com/micromata/awesome-css-learning) - An awesome list limited to the best CSS learning resources.
+
+## Roadmap
+
+[JavaScript](https://roadmap.sh/javascript) - An awesome roadmap for JavaScript.


### PR DESCRIPTION
Hi Michael,

I came across your repository [awesome-javascript-learning](https://github.com/micromata/awesome-javascript-learning) and found it to be a valuable resource for JavaScript enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["JavaScript Roadmap"](https://roadmap.sh/javascript). I took the initiative to submit a ["Pull Request"](https://github.com/micromata/awesome-javascript-learning/pull/83) adding it in a separate roadmap section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz